### PR TITLE
Accurate logs to milliseconds to get correct order of logs

### DIFF
--- a/src/NLog.Targets.GraylogHttp.Tests/MessageBuilderTests.cs
+++ b/src/NLog.Targets.GraylogHttp.Tests/MessageBuilderTests.cs
@@ -16,9 +16,9 @@ namespace NLog.Targets.GraylogHttp.Tests
                 .WithProperty("host", "magic")
                 .WithLevel(LogLevel.Debug)
                 .WithCustomProperty("logger_name", "SimpleMessageTest")
-                .Render(new DateTime(1970, 1, 1, 0, 0, 10, DateTimeKind.Utc));
+                .Render(new DateTime(1970, 1, 1, 0, 0, 10, 5, DateTimeKind.Utc));
 
-            var expectedMessage = "{\"_facility\":\"Test\",\"short_message\":\"short_message\",\"host\":\"magic\",\"level\":7,\"_logger_name\":\"SimpleMessageTest\",\"timestamp\":10,\"version\":\"1.1\"}";
+            var expectedMessage = "{\"_facility\":\"Test\",\"short_message\":\"short_message\",\"host\":\"magic\",\"level\":7,\"_logger_name\":\"SimpleMessageTest\",\"timestamp\":10.005,\"version\":\"1.1\"}";
 
             Assert.Equal(expectedMessage, testMessage);
         }
@@ -35,9 +35,9 @@ namespace NLog.Targets.GraylogHttp.Tests
                 .WithLevel(LogLevel.Debug)
                 .WithCustomProperty("logger_name", "SimpleMessageTest")
                 .WithProperty("longstring", new string('*', 50000))
-                .Render(new DateTime(1970, 1, 1, 0, 0, 10, DateTimeKind.Utc));
+                .Render(new DateTime(1970, 1, 1, 0, 0, 10, 5, DateTimeKind.Utc));
 
-            var expectedMessage = $"{{\"_facility\":\"Test\",\"short_message\":\"short_message\",\"host\":\"magic\",\"level\":7,\"_logger_name\":\"SimpleMessageTest\",\"longstring\":\"{new string('*', 16383)}\",\"timestamp\":10,\"version\":\"1.1\"}}";
+            var expectedMessage = $"{{\"_facility\":\"Test\",\"short_message\":\"short_message\",\"host\":\"magic\",\"level\":7,\"_logger_name\":\"SimpleMessageTest\",\"longstring\":\"{new string('*', 16383)}\",\"timestamp\":10.005,\"version\":\"1.1\"}}";
 
             Assert.Equal(expectedMessage, testMessage);
         }

--- a/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
@@ -54,7 +54,7 @@ namespace NLog.Targets.GraylogHttp
 
         public string Render(DateTime timestamp)
         {
-            WithProperty("timestamp", (long)(timestamp.ToUniversalTime() - _epochTime).TotalSeconds);
+            WithProperty("timestamp", (long)(timestamp.ToUniversalTime() - _epochTime).TotalMilliseconds);
             WithProperty("version", "1.1");
             return _graylogMessage.ToString();
         }

--- a/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
@@ -5,7 +5,7 @@ namespace NLog.Targets.GraylogHttp
     internal class GraylogMessageBuilder
     {
         private readonly JsonObject _graylogMessage = new JsonObject();
-        private static readonly DateTime _epochTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTime _epochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
         public GraylogMessageBuilder WithLevel(LogLevel level)
         {

--- a/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
@@ -54,7 +54,7 @@ namespace NLog.Targets.GraylogHttp
 
         public string Render(DateTime timestamp)
         {
-            WithProperty("timestamp", (long)(timestamp.ToUniversalTime() - _epochTime).TotalMilliseconds);
+            WithProperty("timestamp", (decimal)(timestamp.ToUniversalTime() - _epochTime).TotalSeconds);
             WithProperty("version", "1.1");
             return _graylogMessage.ToString();
         }


### PR DESCRIPTION
Logs in our app need to be more accurate, so can i include a milliseconds not seconds in order to get more correct order of logs