### PR TITLE
Add log level description

### DIFF
--- a/src/NLog.Targets.GraylogHttp/GraylogHttpTarget.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogHttpTarget.cs
@@ -41,6 +41,11 @@ namespace NLog.Targets.GraylogHttp
 
         public int FailureCooldownSeconds { get; set; } = 30;
 
+        /// <summary>
+        /// Send the NLog log level name as a custom field (default true).
+        /// </summary>
+        public bool AddNLogLevelName { get; set; } = true;
+
         [ArrayParameter(typeof(TargetPropertyWithContext), "parameter")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Justification = "NLog Behavior")]
         public override IList<TargetPropertyWithContext> ContextProperties { get; }
@@ -87,8 +92,12 @@ namespace NLog.Targets.GraylogHttp
                 .WithProperty("host", Host)
                 .WithLevel(logEvent.Level)
                 .WithSyslogLevelName(logEvent.Level)
-                .WithNLogLevelName(logEvent.Level)
                 .WithCustomProperty("logger_name", logEvent.LoggerName);
+
+            if (AddNLogLevelName)
+            {
+                messageBuilder.WithNLogLevelName(logEvent.Level);
+            }
 
             if (!string.IsNullOrEmpty(Facility))
                 messageBuilder.WithCustomProperty("facility", Facility);

--- a/src/NLog.Targets.GraylogHttp/GraylogHttpTarget.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogHttpTarget.cs
@@ -87,7 +87,7 @@ namespace NLog.Targets.GraylogHttp
                 .WithProperty("host", Host)
                 .WithLevel(logEvent.Level)
                 .WithSyslogLevelName(logEvent.Level)
-                .WithDotNetLogLevelName(logEvent.Level)
+                .WithNLogLevelName(logEvent.Level)
                 .WithCustomProperty("logger_name", logEvent.LoggerName);
 
             if (!string.IsNullOrEmpty(Facility))

--- a/src/NLog.Targets.GraylogHttp/GraylogHttpTarget.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogHttpTarget.cs
@@ -86,6 +86,7 @@ namespace NLog.Targets.GraylogHttp
                 .WithProperty("short_message", logEvent.FormattedMessage)
                 .WithProperty("host", Host)
                 .WithLevel(logEvent.Level)
+                .WithLevelName(logEvent.Level)
                 .WithCustomProperty("logger_name", logEvent.LoggerName);
 
             if (!string.IsNullOrEmpty(Facility))

--- a/src/NLog.Targets.GraylogHttp/GraylogHttpTarget.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogHttpTarget.cs
@@ -86,7 +86,8 @@ namespace NLog.Targets.GraylogHttp
                 .WithProperty("short_message", logEvent.FormattedMessage)
                 .WithProperty("host", Host)
                 .WithLevel(logEvent.Level)
-                .WithLevelName(logEvent.Level)
+                .WithSyslogLevelName(logEvent.Level)
+                .WithDotNetLogLevelName(logEvent.Level)
                 .WithCustomProperty("logger_name", logEvent.LoggerName);
 
             if (!string.IsNullOrEmpty(Facility))

--- a/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
@@ -4,6 +4,7 @@ namespace NLog.Targets.GraylogHttp
 {
     internal class GraylogMessageBuilder
     {
+        private const string LevelNameProperty = "level_name";
         private readonly JsonObject _graylogMessage = new JsonObject();
         private static readonly DateTime _epochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
@@ -25,6 +26,12 @@ namespace NLog.Targets.GraylogHttp
                 graylogLevel = GelfLevel_Error;
 
             return WithProperty("level", graylogLevel);
+        }
+
+        public GraylogMessageBuilder WithLevelName(LogLevel logEventLevel)
+        {
+            var levelName = GetLevelName(logEventLevel);
+            return WithCustomProperty(LevelNameProperty, levelName);
         }
 
         public GraylogMessageBuilder WithProperty(string propertyName, object value)
@@ -57,6 +64,46 @@ namespace NLog.Targets.GraylogHttp
             WithProperty("timestamp", (decimal)(timestamp.ToUniversalTime() - _epochTime).TotalSeconds);
             WithProperty("version", "1.1");
             return _graylogMessage.ToString();
+        }
+
+        private static string GetLevelName(LogLevel logEventLevel)
+        {
+            if (logEventLevel == LogLevel.Trace)
+            {
+                return "Trace";
+            }
+
+            if (logEventLevel == LogLevel.Debug)
+            {
+                return "Debug";
+            }
+
+            if (logEventLevel == LogLevel.Info)
+            {
+                return "Info";
+            }
+
+            if (logEventLevel == LogLevel.Warn)
+            {
+                return "Warn";
+            }
+
+            if (logEventLevel == LogLevel.Error)
+            {
+                return "Error";
+            }
+
+            if (logEventLevel == LogLevel.Fatal)
+            {
+                return "Fatal";
+            }
+
+            if (logEventLevel == LogLevel.Off)
+            {
+                return "Off";
+            }
+
+            return string.Empty;
         }
 
         private static readonly object GelfLevel_Critical = 2;

--- a/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
@@ -25,10 +25,8 @@ namespace NLog.Targets.GraylogHttp
                 graylogLevel = GelfLevel_Error;
             else if (level == LogLevel.Fatal)
                 graylogLevel = GelfLevel_Critical;
-            else if (level == LogLevel.Off)
-                graylogLevel = 7;
             else
-                graylogLevel = 7; //LogLevel basically null.  Just use Debug (lowest Syslog level).
+                graylogLevel = GelfLevel_Debug;
 
             return WithProperty("level", graylogLevel);
         }
@@ -119,7 +117,7 @@ namespace NLog.Targets.GraylogHttp
                 return "Debug";
             }
 
-            return string.Empty;
+            return "Debug";
         }
 
         private static string GetNLogLevelName(LogLevel logEventLevel)

--- a/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
@@ -4,8 +4,8 @@ namespace NLog.Targets.GraylogHttp
 {
     internal class GraylogMessageBuilder
     {
-        private const string SyslogLevelNameProperty = "SyslogLevelName";
-        private const string DotNetLogLevelNameProperty = "DotNetLogLevelName";
+        private const string SyslogLevelPropertyName = "syslog_level_name";
+        private const string NLogLogLevelPropertyName = "nlog_level_name";
         private readonly JsonObject _graylogMessage = new JsonObject();
         private static readonly DateTime _epochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
 
@@ -36,13 +36,13 @@ namespace NLog.Targets.GraylogHttp
         public GraylogMessageBuilder WithSyslogLevelName(LogLevel logEventLevel)
         {
             var levelName = GetSyslogLevelName(logEventLevel);
-            return WithCustomProperty(SyslogLevelNameProperty, levelName);
+            return WithCustomProperty(SyslogLevelPropertyName, levelName);
         }
 
-        public GraylogMessageBuilder WithDotNetLogLevelName(LogLevel logEventLevel)
+        public GraylogMessageBuilder WithNLogLevelName(LogLevel logEventLevel)
         {
-            var levelName = GetDotNetLogLevelName(logEventLevel);
-            return WithCustomProperty(DotNetLogLevelNameProperty, levelName);
+            var levelName = GetNLogLevelName(logEventLevel);
+            return WithCustomProperty(NLogLogLevelPropertyName, levelName);
         }
 
         public GraylogMessageBuilder WithProperty(string propertyName, object value)
@@ -79,6 +79,11 @@ namespace NLog.Targets.GraylogHttp
 
         private static string GetSyslogLevelName(LogLevel logEventLevel)
         {
+            if (logEventLevel == null)
+            {
+                return string.Empty;
+            }
+
             if (logEventLevel == LogLevel.Trace)
             {
                 return "Debug";
@@ -117,44 +122,14 @@ namespace NLog.Targets.GraylogHttp
             return string.Empty;
         }
 
-        private static string GetDotNetLogLevelName(LogLevel logEventLevel)
+        private static string GetNLogLevelName(LogLevel logEventLevel)
         {
-            if (logEventLevel == LogLevel.Trace)
+            if (logEventLevel == null)
             {
-                return "Trace";
+                return string.Empty;
             }
 
-            if (logEventLevel == LogLevel.Debug)
-            {
-                return "Debug";
-            }
-
-            if (logEventLevel == LogLevel.Info)
-            {
-                return "Informational";
-            }
-
-            if (logEventLevel == LogLevel.Warn)
-            {
-                return "Warning";
-            }
-
-            if (logEventLevel == LogLevel.Error)
-            {
-                return "Error";
-            }
-
-            if (logEventLevel == LogLevel.Fatal)
-            {
-                return "Critical";
-            }
-
-            if (logEventLevel == LogLevel.Off)
-            {
-                return "Trace";
-            }
-
-            return string.Empty;
+            return logEventLevel.Name;
         }
 
         private const byte GelfLevel_Critical = 2;


### PR DESCRIPTION
Setting up a custom pipeline in Graylog for adding a field with the level name can be annoying and can cause performance issues.

My changes allow for the log level name to be sent as a custom property in the GELF message.  I think it would be good to have to make filters easier in Graylog.  

Let me know what you think.
Thanks!