### PR TITLE
Added support for structured logging

### DIFF
--- a/src/NLog.Targets.GraylogHttp/GraylogHttpTarget.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogHttpTarget.cs
@@ -45,6 +45,8 @@ namespace NLog.Targets.GraylogHttp
 
         public int FailureCooldownSeconds { get; set; } = 30;
 
+        public string StructuredLoggingParameterName { get; set; }
+
         /// <summary>
         /// Send the NLog log level name as a custom field (default true).
         /// </summary>
@@ -91,7 +93,7 @@ namespace NLog.Targets.GraylogHttp
             if (logEvent == null)
                 return;
 
-            GraylogMessageBuilder messageBuilder = new GraylogMessageBuilder()
+            GraylogMessageBuilder messageBuilder = new GraylogMessageBuilder(StructuredLoggingParameterName)
                 .WithProperty("short_message", logEvent.FormattedMessage)
                 .WithProperty("host", Host)
                 .WithLevel(logEvent.Level)

--- a/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
@@ -8,6 +8,10 @@ namespace NLog.Targets.GraylogHttp
         private const string NLogLogLevelPropertyName = "nlog_level_name";
         private readonly JsonObject _graylogMessage = new JsonObject();
         private static readonly DateTime _epochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+        private string StructuredLoggingParameterName;
+
+        public void GraylogMessageBuilder(string structuredLoggingParameterName)
+        { StructuredLoggingParameterName = structuredLoggingParameterName  }
 
         public GraylogMessageBuilder WithLevel(LogLevel level)
         {
@@ -65,7 +69,28 @@ namespace NLog.Targets.GraylogHttp
             if (!propertyName.StartsWith("_", StringComparison.Ordinal))
                 propertyName = string.Concat("_", propertyName);
 
-            return WithProperty(propertyName, value);
+            if (StructuredLoggingParameterName != null && propertyName == string.Concat("_", StructuredLoggingParameterName))
+            { return StructuredLogging(value.ToString()); }
+            else
+            { return WithProperty(propertyName, value); }
+
+        }
+
+        private GraylogMessageBuilder StructuredLogging(string value)
+        {
+            if (string.IsNullOrEmpty(value)) {return this;}
+
+            var split = value.Split(new string[] { ", " }, StringSplitOptions.None);
+
+            foreach (string item in split)
+            {
+                var kvPairs = item.Split(new char[] { '=' }, 2);
+                if (kvPairs.Length == 2)
+                {
+                    WithCustomProperty(kvPairs[0].Replace(" ", string.Empty), kvPairs[1]);
+                }
+            }
+            return this;
         }
 
         public string Render(DateTime timestamp)

--- a/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
@@ -8,10 +8,10 @@ namespace NLog.Targets.GraylogHttp
         private const string NLogLogLevelPropertyName = "nlog_level_name";
         private readonly JsonObject _graylogMessage = new JsonObject();
         private static readonly DateTime _epochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-        private string StructuredLoggingParameterName;
+        private string _structuredLoggingParameterName;
 
-        public  GraylogMessageBuilder(string structuredLoggingParameterName)
-        { StructuredLoggingParameterName = structuredLoggingParameterName; }
+        public GraylogMessageBuilder(string structuredLoggingParameterName)
+        { _structuredLoggingParameterName = structuredLoggingParameterName; }
 
         public GraylogMessageBuilder WithLevel(LogLevel level)
         {
@@ -69,16 +69,15 @@ namespace NLog.Targets.GraylogHttp
             if (!propertyName.StartsWith("_", StringComparison.Ordinal))
                 propertyName = string.Concat("_", propertyName);
 
-            if (StructuredLoggingParameterName != null && propertyName == string.Concat("_", StructuredLoggingParameterName))
+            if (_structuredLoggingParameterName != null && propertyName == string.Concat("_", _structuredLoggingParameterName))
             { return StructuredLogging(value.ToString()); }
             else
             { return WithProperty(propertyName, value); }
-
         }
 
         private GraylogMessageBuilder StructuredLogging(string value)
         {
-            if (string.IsNullOrEmpty(value)) {return this;}
+            if (string.IsNullOrEmpty(value)) { return this; }
 
             var split = value.Split(new string[] { ", " }, StringSplitOptions.None);
 
@@ -90,6 +89,7 @@ namespace NLog.Targets.GraylogHttp
                     WithCustomProperty(kvPairs[0].Replace(" ", string.Empty), kvPairs[1]);
                 }
             }
+
             return this;
         }
 

--- a/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
@@ -10,8 +10,8 @@ namespace NLog.Targets.GraylogHttp
         private static readonly DateTime _epochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
         private string StructuredLoggingParameterName;
 
-        public void GraylogMessageBuilder(string structuredLoggingParameterName)
-        { StructuredLoggingParameterName = structuredLoggingParameterName  }
+        public  GraylogMessageBuilder(string structuredLoggingParameterName)
+        { StructuredLoggingParameterName = structuredLoggingParameterName; }
 
         public GraylogMessageBuilder WithLevel(LogLevel level)
         {


### PR DESCRIPTION
This is my first git hub pull request, tell me if I need to do it differently.

I've added structured logging support such that parameters from structured logs appear as individual fields in nlog, not just in one conglomerated field, making reporting much easier.

to use add the StructuredLoggingParameterName parameter, then pass a parameter with the given name and use layout "${all-event-properties}" with no modifiers.

<target name="graylog"
				  xsi:type="GraylogHttp"
				  graylogServer="http://192.168.0.1"
			          graylogPort="12201"
			          StructuredLoggingParameterName="structured_logging">
			<parameter name="structured_logging" layout="${all-event-properties}" />
</target>