### PR TITLE
Added structured logging support 

### DIFF
--- a/src/NLog.Targets.GraylogHttp/GraylogHttpTarget.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogHttpTarget.cs
@@ -45,6 +45,8 @@ namespace NLog.Targets.GraylogHttp
 
         public int FailureCooldownSeconds { get; set; } = 30;
 
+        public string StructuredLoggingParameterName { get; set; }
+
         /// <summary>
         /// Send the NLog log level name as a custom field (default true).
         /// </summary>
@@ -91,7 +93,7 @@ namespace NLog.Targets.GraylogHttp
             if (logEvent == null)
                 return;
 
-            GraylogMessageBuilder messageBuilder = new GraylogMessageBuilder()
+            GraylogMessageBuilder messageBuilder = new GraylogMessageBuilder(StructuredLoggingParameterName)
                 .WithProperty("short_message", logEvent.FormattedMessage)
                 .WithProperty("host", Host)
                 .WithLevel(logEvent.Level)

--- a/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
@@ -10,7 +10,7 @@ namespace NLog.Targets.GraylogHttp
         private static readonly DateTime _epochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
         private string _structuredLoggingParameterName;
 
-        public GraylogMessageBuilder(string structuredLoggingParameterName)
+        public GraylogMessageBuilder(string structuredLoggingParameterName = null)
         { _structuredLoggingParameterName = structuredLoggingParameterName; }
 
         public GraylogMessageBuilder WithLevel(LogLevel level)

--- a/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
@@ -8,6 +8,10 @@ namespace NLog.Targets.GraylogHttp
         private const string NLogLogLevelPropertyName = "nlog_level_name";
         private readonly JsonObject _graylogMessage = new JsonObject();
         private static readonly DateTime _epochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+        private string StructuredLoggingParameterName;
+
+        public void GraylogMessageBuilder(string structuredLoggingParameterName)
+        { StructuredLoggingParameterName = structuredLoggingParameterName  }
 
         public GraylogMessageBuilder WithLevel(LogLevel level)
         {
@@ -65,7 +69,28 @@ namespace NLog.Targets.GraylogHttp
             if (!propertyName.StartsWith("_", StringComparison.Ordinal))
                 propertyName = string.Concat("_", propertyName);
 
-            return WithProperty(propertyName, value);
+            if (StructuredLoggingParameterName != null && propertyName == string.Concat("_", StructuredLoggingParameterName))
+            { return StructuredLogging(value.ToString()); }
+            else
+            { return WithProperty(propertyName, value); }
+
+        }
+
+        private GraylogMessageBuilder StructuredLogging(string value)
+        {
+            if (string.IsNullOrEmpty(value)) {return this;}
+
+            var split = value.Split(new string[] { ", " }, StringSplitOptions.None);
+
+            foreach (string item in split)
+            {
+                var kvPairs = item.Split(new char[] { '=' }, 2);
+                if (kvPairs.Length == 2)
+                {
+                    WithCustomProperty(kvPairs[0].Replace(" ", string.Empty), kvPairs[1]);
+                }
+            }
+            return this;
         }
 
         public string Render(DateTime timestamp)

--- a/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
@@ -8,10 +8,10 @@ namespace NLog.Targets.GraylogHttp
         private const string NLogLogLevelPropertyName = "nlog_level_name";
         private readonly JsonObject _graylogMessage = new JsonObject();
         private static readonly DateTime _epochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-        private string StructuredLoggingParameterName;
+        private string _structuredLoggingParameterName;
 
-        public  GraylogMessageBuilder(string structuredLoggingParameterName)
-        { StructuredLoggingParameterName = structuredLoggingParameterName; }
+        public GraylogMessageBuilder(string structuredLoggingParameterName)
+        { _structuredLoggingParameterName = structuredLoggingParameterName; }
 
         public GraylogMessageBuilder WithLevel(LogLevel level)
         {
@@ -69,16 +69,15 @@ namespace NLog.Targets.GraylogHttp
             if (!propertyName.StartsWith("_", StringComparison.Ordinal))
                 propertyName = string.Concat("_", propertyName);
 
-            if (StructuredLoggingParameterName != null && propertyName == string.Concat("_", StructuredLoggingParameterName))
+            if (_structuredLoggingParameterName != null && propertyName == string.Concat("_", _structuredLoggingParameterName))
             { return StructuredLogging(value.ToString()); }
             else
             { return WithProperty(propertyName, value); }
-
         }
 
         private GraylogMessageBuilder StructuredLogging(string value)
         {
-            if (string.IsNullOrEmpty(value)) {return this;}
+            if (string.IsNullOrEmpty(value)) { return this; }
 
             var split = value.Split(new string[] { ", " }, StringSplitOptions.None);
 
@@ -90,6 +89,7 @@ namespace NLog.Targets.GraylogHttp
                     WithCustomProperty(kvPairs[0].Replace(" ", string.Empty), kvPairs[1]);
                 }
             }
+
             return this;
         }
 

--- a/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
+++ b/src/NLog.Targets.GraylogHttp/GraylogMessageBuilder.cs
@@ -10,8 +10,8 @@ namespace NLog.Targets.GraylogHttp
         private static readonly DateTime _epochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
         private string StructuredLoggingParameterName;
 
-        public void GraylogMessageBuilder(string structuredLoggingParameterName)
-        { StructuredLoggingParameterName = structuredLoggingParameterName  }
+        public  GraylogMessageBuilder(string structuredLoggingParameterName)
+        { StructuredLoggingParameterName = structuredLoggingParameterName; }
 
         public GraylogMessageBuilder WithLevel(LogLevel level)
         {


### PR DESCRIPTION
Im new at this tell me if I've done it wrong.

Have added functionality to handle structured logging, such that the parameters you log against will appear in Greylog as parameters, not just as a conglomerated field.

To use fill in the StructuredLoggingParameterName feild in the config file and assign ${all-event-properties} to a parameter with the same name.

<target name="graylog"
				  xsi:type="GraylogHttp"
				  facility="BFDB"
				  graylogServer="http://192.168.0.119"
			      graylogPort="12201"
			  StructuredLoggingParameterName="structured_logging">
			<parameter name="structured_logging" layout="${all-event-properties}" />
		</target>